### PR TITLE
Prevent mobile page scrolling while dragging the shutter slider

### DIFF
--- a/dist/enhanced-shutter-card.js
+++ b/dist/enhanced-shutter-card.js
@@ -414,6 +414,8 @@ const SHUTTER_CSS =`
         cursor: pointer;
         transform-origin: center;
         transform: var(--esc-transform-picker);
+        touch-action: none;
+        user-select: none;
       }
       .${ESC_CLASS_SELECTOR_SLIDE}org {
         z-index: ${Z_INDEX_SLIDE};
@@ -1226,17 +1228,28 @@ class EnhancedShutter extends LitElement
     //console_log('Shutter Resize detected',this[ESC_CLASS_SELECTOR]?.getBoundingClientRect());
     //console_log('Shutter Update ready');
   }
-  firstUpdated(changedProperties){
-    //console_log('Shutter firstUpdated');
-    this[ESC_CLASS_SELECTOR]        = findElement(this,'.'+ESC_CLASS_SELECTOR);
-    this[ESC_CLASS_SELECTOR_SLIDE]  = findElement(this,'.'+ESC_CLASS_SELECTOR_SLIDE);
-    this[ESC_CLASS_SELECTOR_PICKER] = findElement(this,'.'+ESC_CLASS_SELECTOR_PICKER);
-    // resize observer here .... observer needs  this[ESC_CLASS_SELECTOR] to be set
-    //displayNodePathToTopIncludingShadowAndClass(this[ESC_CLASS_SELECTOR]);
-    this.startResizeObserver();
-    //console_log('Shutter firstUpdated ready');
+  firstUpdated(changedProperties) {
+    super.firstUpdated(changedProperties);
 
+    this[ESC_CLASS_SELECTOR]        = findElement(this, `.${ESC_CLASS_SELECTOR}`);
+    this[ESC_CLASS_SELECTOR_SLIDE]  = findElement(this, `.${ESC_CLASS_SELECTOR_SLIDE}`);
+    // NOTE: drop the old lit‐decorated @touchstart from the template
+    //      so we can re‑attach it manually below
+    const picker = findElement(this, `.${ESC_CLASS_SELECTOR_PICKER}`);
+    if (picker) {
+      // detach any lit‐added touchstart so we don’t double‐fire
+      picker.removeEventListener('touchstart', this.mouseDown);
+
+      // re‐attach as non‑passive so event.preventDefault() works
+      picker.addEventListener('touchstart', this.mouseDown, { passive: false });
+      // pointerdown is non‑passive by default, you can leave it or re‑attach for clarity:
+      picker.addEventListener('pointerdown', this.mouseDown);
+      picker.addEventListener('mousedown',  this.mouseDown);
+    }
+
+    this.startResizeObserver();
   }
+
   startResizeObserver() {
 
     const onResize = (entries) => {
@@ -2547,6 +2560,10 @@ class htmlCard{
           @pointerdown="${this.enhancedShutter.mouseDown}"
           @mousedown="${this.enhancedShutter.mouseDown}"
           @touchstart="${this.enhancedShutter.mouseDown}">
+        </div>
+        <div class="${ESC_CLASS_SELECTOR_PICKER}"
+          @pointerdown=${this.enhancedShutter.mouseDown}
+          style="touch-action: none; user-select: none;">
         </div>
       </div>
     `;

--- a/dist/enhanced-shutter-card.js
+++ b/dist/enhanced-shutter-card.js
@@ -2556,9 +2556,7 @@ class htmlCard{
             </ha-icon>
           </div>
         </div>
-        <div class="${ESC_CLASS_SELECTOR_PICKER}"
-          @pointerdown=${this.enhancedShutter.mouseDown}
-          style="touch-action: none; user-select: none;">
+        <div class="${ESC_CLASS_SELECTOR_PICKER}">
         </div>
       </div>
     `;

--- a/dist/enhanced-shutter-card.js
+++ b/dist/enhanced-shutter-card.js
@@ -2557,11 +2557,6 @@ class htmlCard{
           </div>
         </div>
         <div class="${ESC_CLASS_SELECTOR_PICKER}"
-          @pointerdown="${this.enhancedShutter.mouseDown}"
-          @mousedown="${this.enhancedShutter.mouseDown}"
-          @touchstart="${this.enhancedShutter.mouseDown}">
-        </div>
-        <div class="${ESC_CLASS_SELECTOR_PICKER}"
           @pointerdown=${this.enhancedShutter.mouseDown}
           style="touch-action: none; user-select: none;">
         </div>

--- a/dist/enhanced-shutter-card.js
+++ b/dist/enhanced-shutter-card.js
@@ -1229,8 +1229,6 @@ class EnhancedShutter extends LitElement
     //console_log('Shutter Update ready');
   }
   firstUpdated(changedProperties) {
-    super.firstUpdated(changedProperties);
-
     this[ESC_CLASS_SELECTOR]        = findElement(this, `.${ESC_CLASS_SELECTOR}`);
     this[ESC_CLASS_SELECTOR_SLIDE]  = findElement(this, `.${ESC_CLASS_SELECTOR_SLIDE}`);
     // NOTE: drop the old lit‐decorated @touchstart from the template


### PR DESCRIPTION
### What changed

- Added `touch‑action: none` and `user‑select: none` to the picker div so browsers won’t hijack touch drags as page scrolls.
- Moved all event binding for the shutter “picker” into `firstUpdated()`, re‑attaching the `touchstart` listener with `{ passive: false }`. This ensures our `event.preventDefault()` in `mouseDown()` actually stops native panning.
- Simplified template to only use a single `@pointerdown` on the picker.
- Removed redundant `@touchstart`/`@mousedown` bindings from the template.

### Why

On mobile, dragging the little shutter handle was being intercepted as a page scroll.  By disabling the native touch‑action and using a non‑passive listener we fully capture the drag and prevent the dashboard from scrolling.

### Before

- Touch‑dragging the handle scrolled the whole page instead of moving the shutter.

### After

- Touch‑drag now only moves the shutter. Page scrolling outside the picker remains unaffected.