### PR TITLE
Prevent scrolling on mobile shutter dragging

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ and choose type: `Dashboard`.
 - #### Horizontal moving shutters (left to right, right to left)
   Horizontal moving shutters are now possible. Add `closing_direction` to your settings, and give it the value `left`, `right` or `down`.
   Setting `down` is default.
-  
+
   ![Curtain](Curtain.gif)
-  
+
   For horizontal moving shutters (curtains), a new image is added: `esc_curtain.png`
 - #### Warnings (unknown/deprected/removed items) while editing the shutters in YAML.
   To help you with defining your settings, unknown/deprecated/removed messaged are shown when defing your card in YAML.
@@ -73,7 +73,7 @@ and choose type: `Dashboard`.
   New settings `scale_icons` for activating scaling of the icons when the image is made smaller.
   ![image](https://github.com/user-attachments/assets/4c0ad49b-e003-4ca8-a64f-3b1fea6d5b68)
 
-- #### Solved [Error#46 ](https://github.com/marcelhoogantink/enhanced-shutter-card/issues/46) (Custom element does not exist) 
+- #### Solved [Error#46 ](https://github.com/marcelhoogantink/enhanced-shutter-card/issues/46) (Custom element does not exist)
   This bug is found and removed.
 
 - #### Improved sizing of the Card

--- a/dist/enhanced-shutter-card.js
+++ b/dist/enhanced-shutter-card.js
@@ -1196,8 +1196,6 @@ class EnhancedShutter extends LitElement
     this.action = '#';
 
     this[ESC_CLASS_SELECTOR]=null;
-    this[ESC_CLASS_SELECTOR_PICKER]=null;
-    this[ESC_CLASS_SELECTOR_SLIDE]=null;
 
     console_log('Version:',this.version);
 
@@ -1229,18 +1227,16 @@ class EnhancedShutter extends LitElement
     //console_log('Shutter Update ready');
   }
   firstUpdated(changedProperties) {
-    this[ESC_CLASS_SELECTOR]        = findElement(this, `.${ESC_CLASS_SELECTOR}`);
-    this[ESC_CLASS_SELECTOR_SLIDE]  = findElement(this, `.${ESC_CLASS_SELECTOR_SLIDE}`);
+    this[ESC_CLASS_SELECTOR] = findElement(this, `.${ESC_CLASS_SELECTOR}`);
     // NOTE: drop the old lit‐decorated @touchstart from the template
     //      so we can re‑attach it manually below
     const picker = findElement(this, `.${ESC_CLASS_SELECTOR_PICKER}`);
     if (picker) {
       // detach any lit‐added touchstart so we don’t double‐fire
-      picker.removeEventListener('touchstart', this.mouseDown);
-
+      //picker.removeEventListener('touchstart', this.mouseDown);
       // re‐attach as non‑passive so event.preventDefault() works
+      // NOTE: this is a workaround for the lit‐element bug where touchstart is always passive
       picker.addEventListener('touchstart', this.mouseDown, { passive: false });
-      // pointerdown is non‑passive by default, you can leave it or re‑attach for clarity:
       picker.addEventListener('pointerdown', this.mouseDown);
       picker.addEventListener('mousedown',  this.mouseDown);
     }

--- a/dist/enhanced-shutter-card.js
+++ b/dist/enhanced-shutter-card.js
@@ -414,6 +414,8 @@ const SHUTTER_CSS =`
         cursor: pointer;
         transform-origin: center;
         transform: var(--esc-transform-picker);
+        touch-action: none;
+        user-select: none;
       }
       .${ESC_CLASS_SELECTOR_SLIDE}org {
         z-index: ${Z_INDEX_SLIDE};
@@ -1226,17 +1228,26 @@ class EnhancedShutter extends LitElement
     //console_log('Shutter Resize detected',this[ESC_CLASS_SELECTOR]?.getBoundingClientRect());
     //console_log('Shutter Update ready');
   }
-  firstUpdated(changedProperties){
-    //console_log('Shutter firstUpdated');
-    this[ESC_CLASS_SELECTOR]        = findElement(this,'.'+ESC_CLASS_SELECTOR);
-    this[ESC_CLASS_SELECTOR_SLIDE]  = findElement(this,'.'+ESC_CLASS_SELECTOR_SLIDE);
-    this[ESC_CLASS_SELECTOR_PICKER] = findElement(this,'.'+ESC_CLASS_SELECTOR_PICKER);
-    // resize observer here .... observer needs  this[ESC_CLASS_SELECTOR] to be set
-    //displayNodePathToTopIncludingShadowAndClass(this[ESC_CLASS_SELECTOR]);
-    this.startResizeObserver();
-    //console_log('Shutter firstUpdated ready');
+  firstUpdated(changedProperties) {
+    this[ESC_CLASS_SELECTOR]        = findElement(this, `.${ESC_CLASS_SELECTOR}`);
+    this[ESC_CLASS_SELECTOR_SLIDE]  = findElement(this, `.${ESC_CLASS_SELECTOR_SLIDE}`);
+    // NOTE: drop the old lit‐decorated @touchstart from the template
+    //      so we can re‑attach it manually below
+    const picker = findElement(this, `.${ESC_CLASS_SELECTOR_PICKER}`);
+    if (picker) {
+      // detach any lit‐added touchstart so we don’t double‐fire
+      picker.removeEventListener('touchstart', this.mouseDown);
 
+      // re‐attach as non‑passive so event.preventDefault() works
+      picker.addEventListener('touchstart', this.mouseDown, { passive: false });
+      // pointerdown is non‑passive by default, you can leave it or re‑attach for clarity:
+      picker.addEventListener('pointerdown', this.mouseDown);
+      picker.addEventListener('mousedown',  this.mouseDown);
+    }
+
+    this.startResizeObserver();
   }
+
   startResizeObserver() {
 
     const onResize = (entries) => {
@@ -2543,10 +2554,7 @@ class htmlCard{
             </ha-icon>
           </div>
         </div>
-        <div class="${ESC_CLASS_SELECTOR_PICKER}"
-          @pointerdown="${this.enhancedShutter.mouseDown}"
-          @mousedown="${this.enhancedShutter.mouseDown}"
-          @touchstart="${this.enhancedShutter.mouseDown}">
+        <div class="${ESC_CLASS_SELECTOR_PICKER}">
         </div>
       </div>
     `;


### PR DESCRIPTION
Solve #72  (Unable to open/close the shutter in scroll view on mobile)