### PR TITLE
Remove empty extra row/column of icons

### DIFF
--- a/dist/enhanced-shutter-card.js
+++ b/dist/enhanced-shutter-card.js
@@ -3136,7 +3136,7 @@ class htmlCard{
     return html`
       ${this.cfg.buttonsRightActive() && !this.cfg.disablePartialOpenButtons()
         ? html`
-            ${[0, 1, 2].map(i => html`
+            ${[0, 1].map(i => html`
               <div class="${ESC_CLASS_BUTTONS}">
                 ${[i * 3, i * 3 + 1, i * 3 + 2].map(j => html`
                   <ha-icon-button


### PR DESCRIPTION
When using `disable_partial_open_buttons: false`, the card is rendering three columns of buttons to the right of the shutter. However, there are only 2 columns of buttons defined, so the third column is just empty and moves the whole card off centre. This simple PR just fixes that rendering loop to create two columns.

Before:
<img width="503" height="289" alt="image" src="https://github.com/user-attachments/assets/3018cdfc-87d9-4cee-9ae9-75360dd5cb06" />

After:
<img width="502" height="290" alt="image" src="https://github.com/user-attachments/assets/0fd0e568-6381-4a68-83b3-ee4daf2e94b9" />
